### PR TITLE
[FIX] Firestore.FieldValue(arrayUnion||arrayRemove)

### DIFF
--- a/src/ios/FirestorePluginJSONHelper.m
+++ b/src/ios/FirestorePluginJSONHelper.m
@@ -229,6 +229,13 @@ static NSString *fieldValueArrayUnion = @"__ARRAYUNION";
 }
 
 + (NSArray *)JSONArrayToArray:(NSString *)array {
-    
+    NSData *data = [array dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error;
+    NSArray *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error != nil) {
+        NSLog(@"Error parsing JSON string: %@", error);
+        return nil;
+    }
+    return result;
 }
 @end


### PR DESCRIPTION
Fixes
`Firestore.Firestore.FieldValue.arrayUnion()`
`Firestore.Firestore.FieldValue.arrayRemove()`

Example use case:
```javascript
var firebaseOptions = {
    "datePrefix": '__DATE:',
    "fieldValueDelete": "__DELETE",
    "fieldValueServerTimestamp": "__SERVERTIMESTAMP",
    "persist": true,
};

Firestore.initialise(firebaseOptions).then(function (db) {
    // Add a second document with a generated ID.
    return db.get().collection("users").doc("someUserId").update({
        fieldName : Firestore.Firestore.FieldValue.arrayUnion('carrot')
    }).catch(function (error) {
        console.error("Error adding document: ", error);
    });
});
```
## Proposed Changes

  - JSONArrayToArray (re)introduce/complete logic

